### PR TITLE
Add shorter time frames and moving average

### DIFF
--- a/historychart.js
+++ b/historychart.js
@@ -224,7 +224,8 @@ console.log("history diagram loaded");
         svg.append("g")
             .attr("transform", "translate(0," + height + ")")
             .call(d3.axisBottom(this.xScale)
-                .tickFormat(d3.timeFormat("%d/%H:%M"))
+            .ticks(6)
+            .tickFormat(d3.timeFormat("%d/%H:%M"))
             );
         let currentY;
         let leftMargin=0;

--- a/historychart.js
+++ b/historychart.js
@@ -275,6 +275,7 @@ console.log("history diagram loaded");
                             return currentY(vf(d))
                         })
                     )
+                    .attr("stroke-dasharray", field.dashed ? "6,3" : null); 
             } else {
                 gr = svg.append("g")
                     .selectAll('dot')

--- a/historychart.js
+++ b/historychart.js
@@ -224,7 +224,7 @@ console.log("history diagram loaded");
         svg.append("g")
             .attr("transform", "translate(0," + height + ")")
             .call(d3.axisBottom(this.xScale)
-                .tickFormat(d3.timeFormat("%d/%Hh"))
+                .tickFormat(d3.timeFormat("%d/%H:%M"))
             );
         let currentY;
         let leftMargin=0;

--- a/index.css
+++ b/index.css
@@ -46,9 +46,10 @@ text {
 }
 
 .startSelect label {
-    display: block;
+    display: flex;
+    justify-content: space-between;
     padding: 0.3em;
-    width: 4em;
+    width: 5em;
 }
 
 .selector {

--- a/index.js
+++ b/index.js
@@ -362,12 +362,10 @@ console.log("history main loaded");
         this.fetch('api/status')
             .then(function(resp){return resp.json()})
             .then(function(data){
-                let hours=data.storeTime;
-                let numHours=5;
-                let selectHours=[];
-                for (let i=numHours;i>=1;i--){
-                    selectHours.push(Math.ceil(i*hours/numHours));
-                }
+                const allHours = [0.25, 0.5, 1, 2, 4, 8, 12, 24, 48, 72]; 
+                let selectHours = allHours.filter(hour => hour < data.storeTime); 
+                selectHours.push(data.storeTime); 
+        
                 let hsParent=document.getElementById('hourSelect');
                 for (let i=0;i<selectHours.length;i++){
                     let hs=createRadio('hour',selectHours[i]+"h",selectHours[i],"hourSelector");

--- a/plugin.js
+++ b/plugin.js
@@ -219,9 +219,9 @@ fileref.addEventListener('load', function () {
                 hours: {type: 'SELECT', default: hours[0], list: hours},
                 yMin: {type: 'STRING', default: ''},
                 yMax: {type: 'STRING', default: ''},
-                showLines: {type: 'BOOLEAN', default: false},
-                movingAverage: {type: 'BOOLEAN', default: false, description: 'adds a line with a moving average'},
-                averagingWindow: {type: 'NUMBER', default: 10, description: 'window size for moving average (only if movingAverage is set)'}
+                showLines: {name: 'show lines', type: 'BOOLEAN', default: false},
+                movingAverage: {name: 'show average', type: 'BOOLEAN', default: false, description: 'adds a line with a moving average'},
+                averagingWindow: {name: 'window size', type: 'NUMBER', default: 10, description: 'window size for moving average (only if movingAverage is set)'}
             };
 
             window.avnav.api.registerWidget(HistoryWidget, widgetParameters);

--- a/plugin.js
+++ b/plugin.js
@@ -141,14 +141,14 @@ fileref.addEventListener('load', function () {
             .catch(function(e){reject(e)});
         })
     }
+    
     const hoursFromData = function (data) {
-        let hours = [];
-        let num = 5;
-        for (let i = num; i >= 1; i--) {
-            hours.push(Math.ceil(i * data.storeTime / num) + "");
-        }
-        return hours;
-    }
+        const allHours = [0.25, 0.5, 1, 2, 4, 8, 12, 24, 48, 72]; 
+        const truncatedHours = allHours.filter(hour => hour < data.storeTime); 
+        truncatedHours.push(data.storeTime); 
+        return truncatedHours.map(String); 
+    };
+
     const getHours = function(){
         return new Promise(function(resolve,reject){
             fetchData()

--- a/plugin.js
+++ b/plugin.js
@@ -106,31 +106,31 @@ let HistoryWidget={
      * @returns 
      */
     addMovingAverage:function(data, windowSize) {
-    const movingAverageData = this.calcMovingAverage(data.data, 1, windowSize);
-    data.data = movingAverageData;
-    const avgFieldName = `${data.fields[0]}_average(${windowSize})`;
-    data.fields.push(avgFieldName);
-    return data;
+        const movingAverageData = this.calcMovingAverage(data.data, 1, windowSize);
+        data.data = movingAverageData;
+        const avgFieldName = `${data.fields[0]}_average(${windowSize})`;
+        data.fields.push(avgFieldName);
+        return data;
     },
 
     calcMovingAverage:function(data, valueIndex, windowSize) {
-    if (!Array.isArray(data) || data.length === 0) return [];
-    if (windowSize <= 0) throw new Error('Window size must be greater than 0');
-    if (valueIndex < 0 || valueIndex >= data[0].length) throw new Error('Invalid value index');
-    const result = [];
-    let sum = 0;
-    for (let i = 0; i < data.length; i++) {
-        sum += data[i][valueIndex];
-        if (i >= windowSize) {
-            sum -= data[i - windowSize][valueIndex];
+        if (!Array.isArray(data) || data.length === 0) return [];
+        if (windowSize <= 0) throw new Error('Window size must be greater than 0');
+        if (valueIndex < 0 || valueIndex >= data[0].length) throw new Error('Invalid value index');
+        const result = [];
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+            sum += data[i][valueIndex];
+            if (i >= windowSize) {
+                sum -= data[i - windowSize][valueIndex];
+            }
+            const count = i < windowSize ? i + 1 : windowSize;
+            const avg = sum / count;
+            let newRow = data[i].slice() 
+            newRow.push(avg);
+            result.push(newRow);
         }
-        const count = i < windowSize ? i + 1 : windowSize;
-        const avg = sum / count;
-        let newRow = data[i].slice() 
-        newRow.push(avg);
-        result.push(newRow);
-    }
-    return result;
+        return result;
     }
 }
 

--- a/plugin.js
+++ b/plugin.js
@@ -47,6 +47,20 @@ let HistoryWidget={
                     formatter: props.fieldFormatter,
                     color: props.color
                 };
+                let fieldDefs=[fieldDef];
+
+                if (props.movingAverage) {
+                    HistoryWidget.addMovingAverage(data, props.averagingWindow);
+                    let fieldDefAvg={
+                        name:props.fieldName + "_avg(" + props.averagingWindow + ")",
+                        formatter: props.fieldFormatter,
+                        color: "#0000ff",
+                        dashed: true,
+                        ownAxis: false
+                    };
+                    fieldDefs.push(fieldDefAvg);
+                }
+
                 let chart=widget.querySelector('.chartFrame');
                 if (! chart) return ;
                 self.sequence=data.sequence;
@@ -70,7 +84,7 @@ let HistoryWidget={
                         })
                         .catch(function(error){})
                 },timerInterval*1000);
-                chartHandler.createChart(data,[fieldDef],props.showLines,props.yMin,props.yMax)
+                chartHandler.createChart(data,fieldDefs,props.showLines,props.yMin,props.yMax);
 
             })
             .catch(function(error){console.log(error)});
@@ -83,10 +97,42 @@ let HistoryWidget={
             window.clearInterval(context.timer);
         }
         context.isActive=false;
+    },
+
+    /**
+     * Adds a moving average field to the data object.
+     * @param {*} data the data object as retrieved from the server 
+     * @param {*} windowSize size of elements to use for moving average
+     * @returns 
+     */
+    addMovingAverage:function(data, windowSize) {
+    const movingAverageData = this.calcMovingAverage(data.data, 1, windowSize);
+    data.data = movingAverageData;
+    const avgFieldName = `${data.fields[0]}_average(${windowSize})`;
+    data.fields.push(avgFieldName);
+    return data;
+    },
+
+    calcMovingAverage:function(data, valueIndex, windowSize) {
+    if (!Array.isArray(data) || data.length === 0) return [];
+    if (windowSize <= 0) throw new Error('Window size must be greater than 0');
+    if (valueIndex < 0 || valueIndex >= data[0].length) throw new Error('Invalid value index');
+    const result = [];
+    let sum = 0;
+    for (let i = 0; i < data.length; i++) {
+        sum += data[i][valueIndex];
+        if (i >= windowSize) {
+            sum -= data[i - windowSize][valueIndex];
+        }
+        const count = i < windowSize ? i + 1 : windowSize;
+        const avg = sum / count;
+        let newRow = data[i].slice() 
+        newRow.push(avg);
+        result.push(newRow);
     }
-
+    return result;
+    }
 }
-
 
 
 
@@ -173,7 +219,9 @@ fileref.addEventListener('load', function () {
                 hours: {type: 'SELECT', default: hours[0], list: hours},
                 yMin: {type: 'STRING', default: ''},
                 yMax: {type: 'STRING', default: ''},
-                showLines: {type: 'BOOLEAN', default: false}
+                showLines: {type: 'BOOLEAN', default: false},
+                movingAverage: {type: 'BOOLEAN', default: false, description: 'adds a line with a moving average'},
+                averagingWindow: {type: 'NUMBER', default: 10, description: 'window size for moving average (only if movingAverage is set)'}
             };
 
             window.avnav.api.registerWidget(HistoryWidget, widgetParameters);

--- a/plugin.js
+++ b/plugin.js
@@ -49,7 +49,7 @@ let HistoryWidget={
                 };
                 let fieldDefs=[fieldDef];
 
-                if (props.movingAverage) {
+                if (props.movingAverage && props.averagingWindow > 1){
                     HistoryWidget.addMovingAverage(data, props.averagingWindow);
                     let fieldDefAvg={
                         name:props.fieldName + "_avg(" + props.averagingWindow + ")",


### PR DESCRIPTION
In order to make the history plugin better suited for plotting sailing parameters like TWS and TWD this pull request adds the following:

- a fixed list of shorter time frames up to data.storeTime: [0.25, 0.5, 1, 2, 4, 8, 12, 24, 48, 72]
- it adds minutes to the x-axis labels
- it reduces the number of ticks on the x-axis to avoid overlapping labels
- the option to plot a moving average within the plugins dashboard widget to easier detect wind shifts

This addresses the issues: 
- [#7](https://github.com/wellenvogel/avnav-history-plugin/issues/7)
- [#3](https://github.com/wellenvogel/avnav-history-plugin/issues/3)

